### PR TITLE
Add IBUFG to xilibs

### DIFF
--- a/xilibs/hdl/IBUFG.v
+++ b/xilibs/hdl/IBUFG.v
@@ -1,0 +1,12 @@
+module IBUFG (/*AUTOARG*/
+   // Outputs
+   O,
+   // Inputs
+   I
+   );
+   input I;
+   output O;
+
+   assign O = I;
+   
+endmodule // IBUFG


### PR DESCRIPTION
This adds a missing variation of the Xilinx I/O buffer primitives

Signed-off-by: Olof Kindgren olof.kindgren@gmail.com
