### PR TITLE
When wait is applied after access is active it sticks

### DIFF
--- a/axi/hdl/esaxi.v
+++ b/axi/hdl/esaxi.v
@@ -1,3 +1,4 @@
+`include "elink_regmap.v"
 module esaxi (/*autoarg*/
    // Outputs
    txwr_access, txwr_packet, txrd_access, txrd_packet, rxrr_wait,

--- a/elink/hdl/ecfg_if.v
+++ b/elink/hdl/ecfg_if.v
@@ -50,7 +50,7 @@ module ecfg_if (/*AUTOARG*/
    /********************************/
    output 	     access_out;
    output [PW-1:0]   packet_out;
-   input 	     wait_in;       //incoming wait 
+   input 	     wait_in;       //incoming wait
    
    //wires
    wire [31:0] 	 dstaddr;
@@ -65,8 +65,7 @@ module ecfg_if (/*AUTOARG*/
    wire 	 mi_en;
    
    //regs;
-   reg 		 access_forward_reg;
-   reg 		 access_out_reg;   
+   reg 		 access_out_reg;
    reg [31:0] 	 dstaddr_reg;
    reg [31:0] 	 srcaddr_reg;
    reg [1:0] 	 datamode_reg;
@@ -100,7 +99,7 @@ module ecfg_if (/*AUTOARG*/
    assign mi_match   = access_in & (dstaddr[31:20]==ID);//TODP:REMOVE
 
    //config select (group 2 and 3)
-   assign mi_cfg_en = mi_match & 
+   assign mi_cfg_en = mi_match &
 		      (dstaddr[19:16]==`EGROUP_MMR) &
 		      (dstaddr[10:8]=={2'b01,rxsel});  
    
@@ -140,16 +139,9 @@ module ecfg_if (/*AUTOARG*/
 			      mi_dout1[63:0] |
 			      mi_dout2[63:0] |
 			      mi_dout3[63:0];
-     
 
-   //Access out packet  
+   //Access out packet
    assign access_forward = (mi_rx_en | mi_rd);
-
-   always @ (posedge clk or negedge nreset)
-     if(!nreset)
-       access_forward_reg <= 1'b0;
-     else
-       access_forward_reg <= access_forward;
 
    always @ (posedge clk or negedge nreset)
      if(!nreset)
@@ -159,9 +151,11 @@ module ecfg_if (/*AUTOARG*/
 
    // Ensure access_out is correctly terminated when wait_in
    // occurs after the start of a sequence of accesses
+   // If not terminated the rxrr fifo or the ecfg_cdc fifo will
+   // continue to fill up with duplicate transactions
    // wait_in eventually propagates further back in the channel
    // and stops the source of the access
-   assign access_out = access_out_reg & access_forward_reg;
+   assign access_out = access_out_reg & ~wait_in;
 
    always @ (posedge clk)
      if(~wait_in)

--- a/elink/hdl/erx_cfg.v
+++ b/elink/hdl/erx_cfg.v
@@ -9,8 +9,8 @@ module erx_cfg (/*AUTOARG*/
    remap_sel, timer_cfg, idelay_value, load_taps, test_mode,
    mailbox_irq_en,
    // Inputs
-   nreset, clk, mi_en, mi_we, mi_addr, mi_din, erx_access, erx_packet,
-   gpio_datain, rx_status
+   nreset, clk, wait_in, mi_en, mi_we, mi_addr, mi_din, erx_access,
+   erx_packet, gpio_datain, rx_status
    );
 
    /******************************/
@@ -28,7 +28,8 @@ module erx_cfg (/*AUTOARG*/
 
    /*****************************/
    /*SIMPLE MEMORY INTERFACE    */
-   /*****************************/    
+   /*****************************/
+   input 	 wait_in;
    input 	 mi_en;         
    input 	 mi_we;            // single we, must write 32 bit words
    input [14:0]  mi_addr;          // complete physical address (no shifting!)
@@ -189,7 +190,10 @@ module erx_cfg (/*AUTOARG*/
 	 `ERX_TESTDATA: mi_dout[31:0] <= {rx_testdata_reg[31:0]};
          default:       mi_dout[31:0] <= 32'd0;
        endcase // case (mi_addr[RFAW+1:2])
-   
+     else if(~wait_in)
+       //Only clear when wait not active
+       mi_dout[31:0] <= 32'd0;
+
 endmodule // ecfg_rx
 
 

--- a/elink/hdl/erx_cfg.v
+++ b/elink/hdl/erx_cfg.v
@@ -189,8 +189,6 @@ module erx_cfg (/*AUTOARG*/
 	 `ERX_TESTDATA: mi_dout[31:0] <= {rx_testdata_reg[31:0]};
          default:       mi_dout[31:0] <= 32'd0;
        endcase // case (mi_addr[RFAW+1:2])
-     else
-       mi_dout[31:0] <= 32'd0;
    
 endmodule // ecfg_rx
 

--- a/elink/hdl/erx_core.v
+++ b/elink/hdl/erx_core.v
@@ -287,6 +287,7 @@ module erx_core (/*AUTOARG*/
    
    erx_cfg erx_cfg (.rx_status    	(rx_status[15:0]),
 		    .timer_cfg		(),
+		    .wait_in		(erx_cfg_wait),
 		     /*AUTOINST*/
 		    // Outputs
 		    .mi_dout		(mi_cfg_dout[DW-1:0]),	 // Templated

--- a/elink/hdl/erx_core.v
+++ b/elink/hdl/erx_core.v
@@ -68,6 +68,7 @@ module erx_core (/*AUTOARG*/
    wire [14:0]		mi_addr;		// From erx_cfgif of ecfg_if.v
    wire [DW-1:0]	mi_cfg_dout;		// From erx_cfg of erx_cfg.v
    wire			mi_cfg_en;		// From erx_cfgif of ecfg_if.v
+   wire			mi_cfg_ug_en;		// From erx_cfgif of ecfg_if.v
    wire [63:0]		mi_din;			// From erx_cfgif of ecfg_if.v
    wire [DW-1:0]	mi_dma_dout;		// From erx_dma of edma.v
    wire			mi_dma_en;		// From erx_cfgif of ecfg_if.v
@@ -182,8 +183,9 @@ module erx_core (/*AUTOARG*/
    /************************************************************/
    /*EMAILBOX                                                  */
    /************************************************************/
-   /*emailbox AUTO_TEMPLATE ( 
-    .mi_en              (mi_cfg_en),
+   /*emailbox AUTO_TEMPLATE (
+    .wait_in            (erx_cfg_wait),
+    .mi_ug_en           (mi_cfg_ug_en),
     .mi_dout            (mi_mailbox_dout[]),
     .wr_clk		(clk),
     .rd_clk		(clk),
@@ -206,7 +208,8 @@ module erx_core (/*AUTOARG*/
 			.rd_clk		(clk),			 // Templated
 			.emesh_access	(emmu_access),		 // Templated
 			.emesh_packet	(emmu_packet[PW-1:0]),	 // Templated
-			.mi_en		(mi_cfg_en),		 // Templated
+			.wait_in	(erx_cfg_wait),		 // Templated
+			.mi_ug_en	(mi_cfg_ug_en),		 // Templated
 			.mi_we		(mi_we),
 			.mi_addr	(mi_addr[RFAW+1:0]),
 			.mailbox_irq_en	(mailbox_irq_en));
@@ -233,6 +236,7 @@ module erx_core (/*AUTOARG*/
 		      .mi_mmu_en	(mi_mmu_en),
 		      .mi_dma_en	(mi_dma_en),
 		      .mi_cfg_en	(mi_cfg_en),
+		      .mi_cfg_ug_en	(mi_cfg_ug_en),
 		      .mi_we		(mi_we),
 		      .mi_addr		(mi_addr[14:0]),
 		      .mi_din		(mi_din[63:0]),

--- a/elink/hdl/etx_arbiter.v
+++ b/elink/hdl/etx_arbiter.v
@@ -152,7 +152,7 @@ module etx_arbiter (/*AUTOARG*/
 	   etx_access        <= 1'b0;   
 	   etx_rr            <= 1'b0;	   
 	end
-      else if (~(etx_wr_wait | etx_rd_wait))
+      else if (~txwr_wait)
 	begin
 	   etx_access         <= access_in ;
 	   etx_rr             <= txrr_grant & ~txrr_wait;
@@ -160,8 +160,10 @@ module etx_arbiter (/*AUTOARG*/
    
    //packet
    always @ (posedge clk)
-     if (access_in & ~(etx_wr_wait | etx_rd_wait))
-	  etx_packet[PW-1:0] <= etx_mux[PW-1:0];	 
+     if (!nreset)
+       etx_packet[PW-1:0] <= 'b0;
+     else if (access_in & ~txwr_wait)
+       etx_packet[PW-1:0] <= etx_mux[PW-1:0];	 
    
 endmodule // etx_arbiter
 // Local Variables:

--- a/elink/hdl/etx_arbiter.v
+++ b/elink/hdl/etx_arbiter.v
@@ -160,9 +160,7 @@ module etx_arbiter (/*AUTOARG*/
    
    //packet
    always @ (posedge clk)
-     if (!nreset)
-       etx_packet[PW-1:0] <= 'b0;
-     else if (access_in & ~txwr_wait)
+     if (access_in & ~txwr_wait)
        etx_packet[PW-1:0] <= etx_mux[PW-1:0];	 
    
 endmodule // etx_arbiter

--- a/elink/hdl/etx_cfg.v
+++ b/elink/hdl/etx_cfg.v
@@ -178,8 +178,6 @@ module etx_cfg (/*AUTOARG*/
 	 `ETX_PACKET:  mi_dout[31:0] <= {tx_packet_reg[31:0]};	 
          default:     mi_dout[31:0] <= 32'd0;
        endcase // case (mi_addr[RFAW+1:2])
-     else
-       mi_dout[31:0] <= 32'd0;
 
 endmodule // ecfg_tx
 

--- a/elink/hdl/etx_cfg.v
+++ b/elink/hdl/etx_cfg.v
@@ -9,8 +9,8 @@ module etx_cfg (/*AUTOARG*/
    mi_dout, tx_enable, mmu_enable, gpio_enable, remap_enable,
    burst_enable, gpio_data, ctrlmode, ctrlmode_bypass,
    // Inputs
-   nreset, clk, mi_en, mi_we, mi_addr, mi_din, tx_status, etx_access,
-   etx_packet
+   nreset, clk, wait_in, mi_en, mi_we, mi_addr, mi_din, tx_status,
+   etx_access, etx_packet
    );
 
    /******************************/
@@ -29,7 +29,8 @@ module etx_cfg (/*AUTOARG*/
 
    /*****************************/
    /*SIMPLE MEMORY INTERFACE    */
-   /*****************************/    
+   /*****************************/
+   input 	     wait_in;
    input 	     mi_en;         
    input 	     mi_we;            
    input [RFAW+1:0]  mi_addr;       // complete address (no shifting!)
@@ -178,6 +179,9 @@ module etx_cfg (/*AUTOARG*/
 	 `ETX_PACKET:  mi_dout[31:0] <= {tx_packet_reg[31:0]};	 
          default:     mi_dout[31:0] <= 32'd0;
        endcase // case (mi_addr[RFAW+1:2])
+     else if(~wait_in)
+       //Only clear when wait not active
+       mi_dout[31:0] <= 32'd0;
 
 endmodule // ecfg_tx
 

--- a/elink/hdl/etx_core.v
+++ b/elink/hdl/etx_core.v
@@ -230,7 +230,7 @@ module etx_core(/*AUTOARG*/
     .\(.*\)_out         (etx_cfg_\1[]),
     .mi_dout0		({32'b0,mi_cfg_dout[31:0]}),
     .mi_dout2		({32'b0,mi_mmu_dout[31:0]}),
-    .wait_in		(etx_cfg_wait),
+    .wait_in		(txwr_wait),
     );
         */
    
@@ -255,7 +255,7 @@ module etx_core(/*AUTOARG*/
 		      .packet_in	(etx_packet[PW-1:0]),	 // Templated
 		      .mi_dout0		({32'b0,mi_cfg_dout[31:0]}), // Templated
 		      .mi_dout2		({32'b0,mi_mmu_dout[31:0]}), // Templated
-		      .wait_in		(etx_cfg_wait));		 // Templated
+		      .wait_in		(txwr_wait));		 // Templated
    
    /************************************************************/
    /* ETX CONFIGURATION REGISTERS                              */

--- a/elink/hdl/etx_core.v
+++ b/elink/hdl/etx_core.v
@@ -239,6 +239,7 @@ module etx_core(/*AUTOARG*/
    ecfg_if etx_cfgif (.mi_dout3		(64'b0),
 		      .mi_dout1		(64'b0), 
 		      .mi_dma_en	(),
+		      .mi_cfg_ug_en	(),
 		      /*AUTOINST*/
 		      // Outputs
 		      .mi_mmu_en	(mi_mmu_en),

--- a/elink/hdl/etx_core.v
+++ b/elink/hdl/etx_core.v
@@ -286,6 +286,7 @@ module etx_core(/*AUTOARG*/
    //configer register file
    defparam etx_cfg.ID = ID;   
    etx_cfg etx_cfg (
+		    .wait_in		(txwr_wait),
 		    /*AUTOINST*/
 		    // Outputs
 		    .mi_dout		(mi_cfg_dout[DW-1:0]),	 // Templated

--- a/emailbox/hdl/emailbox.v
+++ b/emailbox/hdl/emailbox.v
@@ -52,7 +52,7 @@ module emailbox (/*AUTOARG*/
    /*****************************/
    /*32 BIT READ INTERFACE      */
    /*****************************/
-   input 	    wait_in;   
+   input 	    wait_in;
    input 	    mi_ug_en;
    input 	    mi_we;      
    input [RFAW+1:0] mi_addr;
@@ -108,7 +108,7 @@ module emailbox (/*AUTOARG*/
    /*READ BACK DATA (32BIT)     */
    /*****************************/  
 
-   assign mi_rd         = mi_ug_en & ~mi_we;   
+   assign mi_rd         = mi_ug_en & ~mi_we;
    assign mailbox_read  = mi_rd & (mi_addr[RFAW+1:2]==`E_MAILBOXLO); //fifo read
 
    always @ (posedge rd_clk)
@@ -139,6 +139,13 @@ module emailbox (/*AUTOARG*/
 	      read_status <= 1'b0;
 	   end
        endcase // case (mi_addr[RFAW+1:2])
+     else if(~wait_in)
+       //Only clear when wait is not active
+       begin
+	  read_hi     <= 1'b0;
+	  read_lo     <= 1'b0;
+	  read_status <= 1'b0;
+       end
    
    assign mi_dout[31:0]  = ({(32){read_status}} & {30'b0,mailbox_full, mailbox_not_empty} |
 			    {(32){read_hi}} & mailbox_data[63:32] |
@@ -160,8 +167,8 @@ module emailbox (/*AUTOARG*/
      		   .prog_full (),
 		   .valid     (dout_valid),
 		   //Read Port
-		   .rd_en    (mailbox_read & ~wait_in), 
-		   .rd_clk   (rd_clk),  
+		   .rd_en    (mailbox_read & ~wait_in),
+		   .rd_clk   (rd_clk),
 		   //Write Port 
 		   .din      ({40'b0,emesh_din[63:0]}),
 		   .wr_en    (mailbox_write),


### PR DESCRIPTION
This fix attempts to prevent access freezing when wait is applied
after access is active.  There are several places in the hdl where
this problem is likely to occur this is the first of several such fixes

Signed-off-by: Peter Saunderson peteasa@gmail.com
