### PR TITLE
Handling of access during wait

### DIFF
--- a/axi/hdl/esaxi.v
+++ b/axi/hdl/esaxi.v
@@ -1,3 +1,4 @@
+`include "elink_regmap.v"
 module esaxi (/*autoarg*/
    // Outputs
    txwr_access, txwr_packet, txrd_access, txrd_packet, rxrr_wait,

--- a/elink/hdl/ecfg_if.v
+++ b/elink/hdl/ecfg_if.v
@@ -6,8 +6,8 @@
 `include "elink_regmap.v"
 module ecfg_if (/*AUTOARG*/
    // Outputs
-   mi_mmu_en, mi_dma_en, mi_cfg_en, mi_we, mi_addr, mi_din,
-   access_out, packet_out,
+   mi_mmu_en, mi_dma_en, mi_cfg_en, mi_cfg_ug_en, mi_we, mi_addr,
+   mi_din, access_out, packet_out,
    // Inputs
    clk, nreset, access_in, packet_in, mi_dout0, mi_dout1, mi_dout2,
    mi_dout3, wait_in
@@ -36,7 +36,8 @@ module ecfg_if (/*AUTOARG*/
    /********************************/
    output 	 mi_mmu_en;     
    output 	 mi_dma_en;
-   output 	 mi_cfg_en;      
+   output 	 mi_cfg_en;
+   output 	 mi_cfg_ug_en;
    output        mi_we;  
    output [14:0] mi_addr;
    output [63:0] mi_din;   
@@ -50,7 +51,7 @@ module ecfg_if (/*AUTOARG*/
    /********************************/
    output 	     access_out;
    output [PW-1:0]   packet_out;
-   input 	     wait_in;       //incoming wait 
+   input 	     wait_in;       //incoming wait
    
    //wires
    wire [31:0] 	 dstaddr;
@@ -63,9 +64,12 @@ module ecfg_if (/*AUTOARG*/
    wire 	 access_forward;
    wire 	 rxsel;
    wire 	 mi_en;
-   
+   wire 	 mi_cfg_en_local;
+   wire 	 mi_dma_en_local;
+   wire 	 mi_mmu_en_local;
+
    //regs;
-   reg 		 access_out;   
+   reg 		 access_out_reg;
    reg [31:0] 	 dstaddr_reg;
    reg [31:0] 	 srcaddr_reg;
    reg [1:0] 	 datamode_reg;
@@ -99,24 +103,28 @@ module ecfg_if (/*AUTOARG*/
    assign mi_match   = access_in & (dstaddr[31:20]==ID);//TODP:REMOVE
 
    //config select (group 2 and 3)
-   assign mi_cfg_en = mi_match & 
+   assign mi_cfg_en_local = mi_match &
 		      (dstaddr[19:16]==`EGROUP_MMR) &
-		      (dstaddr[10:8]=={2'b01,rxsel});  
+		      (dstaddr[10:8]=={2'b01,rxsel});
+   assign mi_cfg_en = mi_cfg_en_local & ~wait_in;
+   assign mi_cfg_ug_en = mi_cfg_en_local;
    
    //dma select (group 5)
-   assign mi_dma_en = mi_match &
+   assign mi_dma_en_local = mi_match &
 		      (dstaddr[19:16]==`EGROUP_MMR) & 
 		      (dstaddr[10:8]==3'h5)  & 
 		      (dstaddr[5]==rxsel);
-
+   assign mi_dma_en = mi_dma_en_local & ~wait_in;
+   
    //mmu select
-   assign mi_mmu_en = mi_match & 
+   assign mi_mmu_en_local = mi_match & 
 		      (dstaddr[19:16]==`EGROUP_MMU) &
 		      (dstaddr[15]==rxsel);
-
+   assign mi_mmu_en = mi_mmu_en_local & ~wait_in;
+   
    //read/write indicator
-   assign mi_en = (mi_mmu_en | mi_cfg_en | mi_dma_en);   
-   assign mi_rd = ~write & mi_en;   
+   assign mi_en = (mi_mmu_en_local | mi_cfg_en_local | mi_dma_en_local);   
+   assign mi_rd = ~write & mi_en;
    assign mi_we = write  & mi_en;
    
    //signal to carry transaction from ETX to ERX block through fifo_cdc
@@ -139,17 +147,24 @@ module ecfg_if (/*AUTOARG*/
 			      mi_dout1[63:0] |
 			      mi_dout2[63:0] |
 			      mi_dout3[63:0];
-     
 
-   //Access out packet  
+   //Access out packet
    assign access_forward = (mi_rx_en | mi_rd);
 
    always @ (posedge clk or negedge nreset)
      if(!nreset)
-       access_out <= 1'b0;   
-     else if(~wait_in)
-       access_out   <= access_forward;
-   
+       access_out_reg <= 1'b0;
+     else if(!wait_in)
+       access_out_reg <= access_forward;
+
+   // Ensure access_out is correctly terminated when wait_in
+   // occurs after the start of a sequence of accesses
+   // If not terminated the rxrr fifo or the ecfg_cdc fifo will
+   // continue to fill up with duplicate transactions
+   // wait_in eventually propagates further back in the channel
+   // and stops the source of the access
+   assign access_out = access_out_reg & ~wait_in;
+
    always @ (posedge clk)
      if(~wait_in)
        begin

--- a/elink/hdl/erx_cfg.v
+++ b/elink/hdl/erx_cfg.v
@@ -9,8 +9,8 @@ module erx_cfg (/*AUTOARG*/
    remap_sel, timer_cfg, idelay_value, load_taps, test_mode,
    mailbox_irq_en,
    // Inputs
-   nreset, clk, mi_en, mi_we, mi_addr, mi_din, erx_access, erx_packet,
-   gpio_datain, rx_status
+   nreset, clk, wait_in, mi_en, mi_we, mi_addr, mi_din, erx_access,
+   erx_packet, gpio_datain, rx_status
    );
 
    /******************************/
@@ -28,7 +28,8 @@ module erx_cfg (/*AUTOARG*/
 
    /*****************************/
    /*SIMPLE MEMORY INTERFACE    */
-   /*****************************/    
+   /*****************************/
+   input 	 wait_in;
    input 	 mi_en;         
    input 	 mi_we;            // single we, must write 32 bit words
    input [14:0]  mi_addr;          // complete physical address (no shifting!)
@@ -189,9 +190,12 @@ module erx_cfg (/*AUTOARG*/
 	 `ERX_TESTDATA: mi_dout[31:0] <= {rx_testdata_reg[31:0]};
          default:       mi_dout[31:0] <= 32'd0;
        endcase // case (mi_addr[RFAW+1:2])
-     else
+     else if(~wait_in & ~ecfg_read)
+       //Only clear when wait not active
        mi_dout[31:0] <= 32'd0;
-   
+     else if (wait_in)
+       mi_dout[31:0] <= mi_dout[31:0];
+
 endmodule // ecfg_rx
 
 

--- a/elink/hdl/erx_core.v
+++ b/elink/hdl/erx_core.v
@@ -68,6 +68,7 @@ module erx_core (/*AUTOARG*/
    wire [14:0]		mi_addr;		// From erx_cfgif of ecfg_if.v
    wire [DW-1:0]	mi_cfg_dout;		// From erx_cfg of erx_cfg.v
    wire			mi_cfg_en;		// From erx_cfgif of ecfg_if.v
+   wire			mi_cfg_ug_en;		// From erx_cfgif of ecfg_if.v
    wire [63:0]		mi_din;			// From erx_cfgif of ecfg_if.v
    wire [DW-1:0]	mi_dma_dout;		// From erx_dma of edma.v
    wire			mi_dma_en;		// From erx_cfgif of ecfg_if.v
@@ -182,8 +183,9 @@ module erx_core (/*AUTOARG*/
    /************************************************************/
    /*EMAILBOX                                                  */
    /************************************************************/
-   /*emailbox AUTO_TEMPLATE ( 
-    .mi_en              (mi_cfg_en),
+   /*emailbox AUTO_TEMPLATE (
+    .wait_in            (erx_cfg_wait),
+    .mi_ug_en           (mi_cfg_ug_en),
     .mi_dout            (mi_mailbox_dout[]),
     .wr_clk		(clk),
     .rd_clk		(clk),
@@ -206,7 +208,8 @@ module erx_core (/*AUTOARG*/
 			.rd_clk		(clk),			 // Templated
 			.emesh_access	(emmu_access),		 // Templated
 			.emesh_packet	(emmu_packet[PW-1:0]),	 // Templated
-			.mi_en		(mi_cfg_en),		 // Templated
+			.wait_in	(erx_cfg_wait),		 // Templated
+			.mi_ug_en	(mi_cfg_ug_en),		 // Templated
 			.mi_we		(mi_we),
 			.mi_addr	(mi_addr[RFAW+1:0]),
 			.mailbox_irq_en	(mailbox_irq_en));
@@ -233,6 +236,7 @@ module erx_core (/*AUTOARG*/
 		      .mi_mmu_en	(mi_mmu_en),
 		      .mi_dma_en	(mi_dma_en),
 		      .mi_cfg_en	(mi_cfg_en),
+		      .mi_cfg_ug_en	(mi_cfg_ug_en),
 		      .mi_we		(mi_we),
 		      .mi_addr		(mi_addr[14:0]),
 		      .mi_din		(mi_din[63:0]),
@@ -283,6 +287,7 @@ module erx_core (/*AUTOARG*/
    
    erx_cfg erx_cfg (.rx_status    	(rx_status[15:0]),
 		    .timer_cfg		(),
+		    .wait_in	(erx_cfg_wait),
 		     /*AUTOINST*/
 		    // Outputs
 		    .mi_dout		(mi_cfg_dout[DW-1:0]),	 // Templated

--- a/elink/hdl/etx_arbiter.v
+++ b/elink/hdl/etx_arbiter.v
@@ -152,7 +152,7 @@ module etx_arbiter (/*AUTOARG*/
 	   etx_access        <= 1'b0;   
 	   etx_rr            <= 1'b0;	   
 	end
-      else if (~(etx_wr_wait | etx_rd_wait))
+      else if (~txwr_wait)
 	begin
 	   etx_access         <= access_in ;
 	   etx_rr             <= txrr_grant & ~txrr_wait;
@@ -160,8 +160,8 @@ module etx_arbiter (/*AUTOARG*/
    
    //packet
    always @ (posedge clk)
-     if (access_in & ~(etx_wr_wait | etx_rd_wait))
-	  etx_packet[PW-1:0] <= etx_mux[PW-1:0];	 
+     if (access_in & ~txwr_wait)
+       etx_packet[PW-1:0] <= etx_mux[PW-1:0];	 
    
 endmodule // etx_arbiter
 // Local Variables:

--- a/elink/hdl/etx_cfg.v
+++ b/elink/hdl/etx_cfg.v
@@ -9,8 +9,8 @@ module etx_cfg (/*AUTOARG*/
    mi_dout, tx_enable, mmu_enable, gpio_enable, remap_enable,
    burst_enable, gpio_data, ctrlmode, ctrlmode_bypass,
    // Inputs
-   nreset, clk, mi_en, mi_we, mi_addr, mi_din, tx_status, etx_access,
-   etx_packet
+   nreset, clk, wait_in, mi_en, mi_we, mi_addr, mi_din, tx_status,
+   etx_access, etx_packet
    );
 
    /******************************/
@@ -29,7 +29,8 @@ module etx_cfg (/*AUTOARG*/
 
    /*****************************/
    /*SIMPLE MEMORY INTERFACE    */
-   /*****************************/    
+   /*****************************/
+   input 	     wait_in;
    input 	     mi_en;         
    input 	     mi_we;            
    input [RFAW+1:0]  mi_addr;       // complete address (no shifting!)
@@ -178,8 +179,11 @@ module etx_cfg (/*AUTOARG*/
 	 `ETX_PACKET:  mi_dout[31:0] <= {tx_packet_reg[31:0]};	 
          default:     mi_dout[31:0] <= 32'd0;
        endcase // case (mi_addr[RFAW+1:2])
-     else
+     else if(~wait_in & ~ecfg_read)
+       //Only clear when wait not active
        mi_dout[31:0] <= 32'd0;
+     else if (wait_in)
+       mi_dout[31:0] <= mi_dout[31:0];
 
 endmodule // ecfg_tx
 

--- a/elink/hdl/etx_core.v
+++ b/elink/hdl/etx_core.v
@@ -230,7 +230,7 @@ module etx_core(/*AUTOARG*/
     .\(.*\)_out         (etx_cfg_\1[]),
     .mi_dout0		({32'b0,mi_cfg_dout[31:0]}),
     .mi_dout2		({32'b0,mi_mmu_dout[31:0]}),
-    .wait_in		(etx_cfg_wait),
+    .wait_in		(txwr_wait),
     );
         */
    
@@ -239,6 +239,7 @@ module etx_core(/*AUTOARG*/
    ecfg_if etx_cfgif (.mi_dout3		(64'b0),
 		      .mi_dout1		(64'b0), 
 		      .mi_dma_en	(),
+		      .mi_cfg_ug_en	(),
 		      /*AUTOINST*/
 		      // Outputs
 		      .mi_mmu_en	(mi_mmu_en),
@@ -255,7 +256,7 @@ module etx_core(/*AUTOARG*/
 		      .packet_in	(etx_packet[PW-1:0]),	 // Templated
 		      .mi_dout0		({32'b0,mi_cfg_dout[31:0]}), // Templated
 		      .mi_dout2		({32'b0,mi_mmu_dout[31:0]}), // Templated
-		      .wait_in		(etx_cfg_wait));		 // Templated
+		      .wait_in		(txwr_wait));		 // Templated
    
    /************************************************************/
    /* ETX CONFIGURATION REGISTERS                              */
@@ -285,6 +286,7 @@ module etx_core(/*AUTOARG*/
    //configer register file
    defparam etx_cfg.ID = ID;   
    etx_cfg etx_cfg (
+		    .wait_in		(txwr_wait),
 		    /*AUTOINST*/
 		    // Outputs
 		    .mi_dout		(mi_cfg_dout[DW-1:0]),	 // Templated

--- a/emailbox/hdl/emailbox.v
+++ b/emailbox/hdl/emailbox.v
@@ -23,8 +23,8 @@ module emailbox (/*AUTOARG*/
    // Outputs
    mi_dout, mailbox_irq,
    // Inputs
-   nreset, wr_clk, rd_clk, emesh_access, emesh_packet, mi_en, mi_we,
-   mi_addr, mailbox_irq_en
+   nreset, wr_clk, rd_clk, emesh_access, emesh_packet, wait_in,
+   mi_ug_en, mi_we, mi_addr, mailbox_irq_en
    );
 
    parameter DW     = 32;        //data width of fifo
@@ -51,9 +51,10 @@ module emailbox (/*AUTOARG*/
    
    /*****************************/
    /*32 BIT READ INTERFACE      */
-   /*****************************/   
-   input 	    mi_en;
-   input  	    mi_we;      
+   /*****************************/
+   input 	    wait_in;
+   input 	    mi_ug_en;
+   input 	    mi_we;      
    input [RFAW+1:0] mi_addr;
    output [63:0]    mi_dout;   
    
@@ -69,6 +70,7 @@ module emailbox (/*AUTOARG*/
    reg 		  mi_rd_reg;   
    reg [RFAW+1:2] mi_addr_reg;
    reg 		  read_hi;
+   reg 		  read_lo;
    reg 		  read_status;
    reg 		  mi_rd_mailbox;
    
@@ -106,22 +108,56 @@ module emailbox (/*AUTOARG*/
    /*READ BACK DATA (32BIT)     */
    /*****************************/  
 
-   assign mi_rd         = mi_en & ~mi_we;   
+   assign mi_rd         = mi_ug_en & ~mi_we;
    assign mailbox_read  = mi_rd & (mi_addr[RFAW+1:2]==`E_MAILBOXLO); //fifo read
 
    always @ (posedge rd_clk)
-     begin
-	read_hi     <= mi_rd & (mi_addr[RFAW+1:2]==`E_MAILBOXHI);
-	read_status <= mi_rd & (mi_addr[RFAW+1:2]==`E_MAILBOXSTAT);
+     if (mi_rd & ~wait_in)
+       case(mi_addr[RFAW+1:2])
+	 `E_MAILBOXHI:
+	   begin
+	      read_hi     <= 1'b1;
+	      read_lo     <= 1'b0;
+	      read_status <= 1'b0;
+	   end
+	 `E_MAILBOXLO:
+	   begin
+	      read_hi     <= 1'b0;
+	      read_lo     <= 1'b1;
+	      read_status <= 1'b0;
+	   end
+	 `E_MAILBOXSTAT:
+	   begin
+	      read_hi     <= 1'b0;
+	      read_lo     <= 1'b0;
+	      read_status <= 1'b1;
+	   end
+	 default:
+	   begin
+	      read_hi     <= 1'b0;
+	      read_lo     <= 1'b0;
+	      read_status <= 1'b0;
+	   end
+       endcase // case (mi_addr[RFAW+1:2])
+     else if(~mi_rd & ~wait_in)
+       //Only clear when wait is not active
+       begin
+	  read_hi     <= 1'b0;
+	  read_lo     <= 1'b0;
+	  read_status <= 1'b0;
+       end
+     else if(wait_in)
+        begin
+	  read_hi     <= read_hi;
+	  read_lo     <= read_lo;
+	  read_status <= read_status;
+       end      
 
-	// mi_en (mi_cfg_en) is active for all ERX_CFG accesses 
-	// generate a filter for just mailbox accesses
-	mi_rd_mailbox  <= mailbox_read | mi_rd & (mi_addr[RFAW+1:2]==`E_MAILBOXHI) | mi_rd & (mi_addr[RFAW+1:2]==`E_MAILBOXSTAT);
-     end
-   assign mi_dout[31:0]  = read_status ? {30'b0,mailbox_full, mailbox_not_empty} :
-			   read_hi     ? mailbox_data[63:32]                     : 
-			                 {{(DW){mi_rd_mailbox}} & mailbox_data[31:0]};
-   assign mi_dout[63:32] = {{(DW){mi_rd_mailbox}} & mailbox_data[63:32]};
+   assign mi_dout[31:0]  = ({(32){read_status}} & {30'b0,mailbox_full, mailbox_not_empty} |
+			    {(32){read_hi}} & mailbox_data[63:32] |
+			    {(32){read_lo}} & mailbox_data[31:0]);
+   assign mi_dout[63:32] = ({(32){read_hi}} & mailbox_data[63:32] |
+			    {(32){read_lo}} & mailbox_data[63:32]);
    
    /*****************************/
    /*FIFO (64bit wide)          */
@@ -137,8 +173,8 @@ module emailbox (/*AUTOARG*/
      		   .prog_full (),
 		   .valid     (dout_valid),
 		   //Read Port
-		   .rd_en    (mailbox_read), 
-		   .rd_clk   (rd_clk),  
+		   .rd_en    (mailbox_read & ~wait_in),
+		   .rd_clk   (rd_clk),
 		   //Write Port 
 		   .din      ({40'b0,emesh_din[63:0]}),
 		   .wr_en    (mailbox_write),


### PR DESCRIPTION
fifo tx side holds access high until either tx_ack_wait or empty or wait from receiver
Register read may occur just prior to wait and take more than once cycle to complete
The Register read result must be held during wait
After the wait the Register read result has stored and then written to the rr fifo or the ecfg_cdc fifo
This fix ensures that ecfg_if reapplies access_out in the first cycle after ~wait_in.

On the tx channel etx_cfgif previously used etx_cfg_wait..
If an access caused etx_wr_wait or etx_rd_wait but not ctx_cfg_wait
then the write cycle to the ecfg_cdc fifo would not be paused and duplicate entries get stored in ecfg_cdc
This fixes this problem by using txwr_wait rather than ctx_cfg_wait

The mailbox read to the mi_dout_mux bus has been made as close as possible to those of the
register read to ensure that in common with register accesses the read result is held during wait
ready to be written to the rr fifo after the wait cycle has completed.

The access_out signal is held off during wait_in active and reapplied following the wait cycles.

Signed-off-by: Peter Saunderson peteasa@gmail.com
