### PR TITLE
oh_fifo_sync: Fix Vivado error

### DIFF
--- a/common/hdl/oh_fifo_sync.v
+++ b/common/hdl/oh_fifo_sync.v
@@ -11,7 +11,7 @@ module oh_fifo_sync (/*AUTOARG*/
    parameter  DEPTH       = 4;
    parameter  DW          = 104;
    parameter  PROG_FULL   = DEPTH/2;
-   localparam AW          = $clog2(DEPTH);
+   parameter  AW          = $clog2(DEPTH);
 
    //clk/reset
    input 	   clk;          // clock


### PR DESCRIPTION
Fix this error:

```
system function call clog2 is not allowed here
```
