### PR TITLE
Add burst test

### DIFF
--- a/elink/sw/burst-test/README.md
+++ b/elink/sw/burst-test/README.md
@@ -1,0 +1,12 @@
+# Test burst writes
+
+https://github.com/parallella/oh/issues/37
+
+> Remembered that we have a long forgotten mode in the epiphany chip elink
+> (not impemented in the fpga elink) that creates bursts when you write
+> doubles to the same address. (F**K!)
+> So the writes were likely coming in as bursts.
+> Looks like the mailbox works fine when you write in "int"s (I tested it on
+> the board with consecutive)
+> (see "mailbox_test" in elink/sw0)
+

--- a/elink/sw/burst-test/build.sh
+++ b/elink/sw/burst-test/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+ESDK=${EPIPHANY_HOME}
+ELIBS="-L ${ESDK}/tools/host/lib"
+EINCS="-I ${ESDK}/tools/host/include"
+ELDF=${ESDK}/bsps/current/internal.ldf
+
+# Create the binaries directory
+mkdir -p bin/
+
+if [ -z "${CROSS_COMPILE+xxx}" ]; then
+case $(uname -p) in
+	arm*)
+		# Use native arm compiler (no cross prefix)
+		CROSS_COMPILE=
+		;;
+	   *)
+		# Use cross compiler
+		CROSS_COMPILE="arm-linux-gnueabihf-"
+		;;
+esac
+fi
+
+# Build HOST side application
+${CROSS_COMPILE}gcc src/main.c -g -o bin/main.elf  ${EINCS} ${ELIBS} -le-hal -le-loader -lpthread
+
+# Build DEVICE side program
+OPT=3
+e-gcc -g -T ${ELDF} -O${OPT} src/emain.c src/etest.S -o bin/emain.elf -le-lib
+
+

--- a/elink/sw/burst-test/run.sh
+++ b/elink/sw/burst-test/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT=$(readlink -f "$0")
+EXEPATH=$(dirname "$SCRIPT")
+
+
+cd $EXEPATH/bin
+
+./main.elf
+

--- a/elink/sw/burst-test/src/common.h
+++ b/elink/sw/burst-test/src/common.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#define STATUS_ADDR 0x6000
+
+#define NEXPECTED 8
+
+/* External memory */
+#define DRAM_RESULT_OFFSET 0x01100000
+#define DRAM_RESULT_ADDR   0x8f100000
+
+/* On-chip SRAM */
+#define ERAM_RESULT_OFFSET 0x00001000
+#define ERAM_RESULT_ADDR   0x80901000
+
+#define EXPECTED_0 0x12345678
+#define EXPECTED_1 0xffffffff
+#define EXPECTED_2 0xf0f0f0f0
+#define EXPECTED_3 0xffff0000
+#define EXPECTED_4 0xff00ff00
+#define EXPECTED_5 0xaaaaaaaa
+#define EXPECTED_6 0x55555555
+#define EXPECTED_7 0xa55aa55a
+

--- a/elink/sw/burst-test/src/emain.c
+++ b/elink/sw/burst-test/src/emain.c
@@ -1,0 +1,18 @@
+#include <e-lib.h>
+#include <stdint.h>
+
+#include "common.h"
+
+extern void test_dram();
+extern void test_eram();
+
+int main()
+{
+	volatile uint32_t *status = (uint32_t *) STATUS_ADDR;
+
+	test_dram();
+	test_eram();
+
+	/* Tell host we're done */
+	*status = 1;
+}

--- a/elink/sw/burst-test/src/etest.S
+++ b/elink/sw/burst-test/src/etest.S
@@ -1,0 +1,216 @@
+#include "common.h"
+
+/* ANSI concatenation macros.  */
+
+#define CONCAT1(a, b) CONCAT2(a, b)
+#define CONCAT2(a, b) a ## b
+#define STRINGIFY2(a, b) STRINGIFY(a##b)
+#define STRINGIFY(a) #a
+
+/* Use the right prefix for global labels.  */
+
+#define SYM(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
+
+#define FUNC(X)         .type SYM(X),@function
+
+FUNC(test_dram)
+.global SYM(test_dram)
+.align 3
+SYM(test_dram):
+	mov	r20, %low(EXPECTED_0)
+	movt	r20, %high(EXPECTED_0)
+	mov	r21, %low(EXPECTED_1)
+	movt	r21, %high(EXPECTED_1)
+	mov	r22, %low(EXPECTED_2)
+	movt	r22, %high(EXPECTED_2)
+	mov	r23, %low(EXPECTED_3)
+	movt	r23, %high(EXPECTED_3)
+	mov	r24, %low(EXPECTED_4)
+	movt	r24, %high(EXPECTED_4)
+	mov	r25, %low(EXPECTED_5)
+	movt	r25, %high(EXPECTED_5)
+	mov	r26, %low(EXPECTED_6)
+	movt	r26, %high(EXPECTED_6)
+	mov	r27, %low(EXPECTED_7)
+	movt	r27, %high(EXPECTED_7)
+
+	mov	r30, %low(DRAM_RESULT_ADDR)
+	movt	r30, %high(DRAM_RESULT_ADDR)
+
+	# 32-bit writes
+
+	# 1 writes
+	str	r20,[r30],+1
+
+	# 2 writes
+	str	r20,[r30]
+	str	r21,[r30],+1
+
+	# 3 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30],+1
+
+	# 4 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30],+1
+
+	# 5 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30],+1
+
+	# 6 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30]
+	str	r25,[r30],+1
+
+	# 7 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30]
+	str	r25,[r30]
+	str	r26,[r30],+1
+
+	# 8 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30]
+	str	r25,[r30]
+	str	r26,[r30]
+	str	r27,[r30],+1
+
+	;; repeat w/ 64-bit writes
+
+	# 1 writes
+	strd	r20,[r30],+1
+
+	# 2 writes
+	strd	r20,[r30]
+	strd	r22,[r30],+1
+
+	# 3 writes
+	strd	r20,[r30]
+	strd	r22,[r30]
+	strd	r24,[r30],+1
+
+	# 4 writes
+	strd	r20,[r30]
+	strd	r22,[r30]
+	strd	r24,[r30]
+	strd	r26,[r30],+1
+
+	rts
+.size SYM(test_dram), .-SYM(test_dram)
+
+FUNC(test_eram)
+.global SYM(test_eram)
+.align 3
+SYM(test_eram):
+	mov	r20, %low(EXPECTED_0)
+	movt	r20, %high(EXPECTED_0)
+	mov	r21, %low(EXPECTED_1)
+	movt	r21, %high(EXPECTED_1)
+	mov	r22, %low(EXPECTED_2)
+	movt	r22, %high(EXPECTED_2)
+	mov	r23, %low(EXPECTED_3)
+	movt	r23, %high(EXPECTED_3)
+	mov	r24, %low(EXPECTED_4)
+	movt	r24, %high(EXPECTED_4)
+	mov	r25, %low(EXPECTED_5)
+	movt	r25, %high(EXPECTED_5)
+	mov	r26, %low(EXPECTED_6)
+	movt	r26, %high(EXPECTED_6)
+	mov	r27, %low(EXPECTED_7)
+	movt	r27, %high(EXPECTED_7)
+
+	mov	r30, %low(ERAM_RESULT_ADDR)
+	movt	r30, %high(ERAM_RESULT_ADDR)
+
+	# 32-bit writes
+
+	# 1 writes
+	str	r20,[r30],+1
+
+	# 2 writes
+	str	r20,[r30]
+	str	r21,[r30],+1
+
+	# 3 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30],+1
+
+	# 4 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30],+1
+
+	# 5 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30],+1
+
+	# 6 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30]
+	str	r25,[r30],+1
+
+	# 7 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30]
+	str	r25,[r30]
+	str	r26,[r30],+1
+
+	# 8 writes
+	str	r20,[r30]
+	str	r21,[r30]
+	str	r22,[r30]
+	str	r23,[r30]
+	str	r24,[r30]
+	str	r25,[r30]
+	str	r26,[r30]
+	str	r27,[r30],+1
+
+	;; repeat w/ 64-bit writes
+
+	# 1 writes
+	strd	r20,[r30],+1
+
+	# 2 writes
+	strd	r20,[r30]
+	strd	r22,[r30],+1
+
+	# 3 writes
+	strd	r20,[r30]
+	strd	r22,[r30]
+	strd	r24,[r30],+1
+
+	# 4 writes
+	strd	r20,[r30]
+	strd	r22,[r30]
+	strd	r24,[r30]
+	strd	r26,[r30],+1
+
+	rts
+.size SYM(test_eram), .-SYM(test_eram)

--- a/elink/sw/burst-test/src/main.c
+++ b/elink/sw/burst-test/src/main.c
@@ -1,0 +1,145 @@
+// Test burst writes
+// https://github.com/parallella/oh/issues/37
+//
+// "Remembered that we have a long forgotten mode in the epiphany chip elink
+// (not impemented in the fpga elink) that creates bursts when you write
+// doubles to the same address. (F**K!)
+// So the writes were likely coming in as bursts.
+// Looks like the mailbox works fine when you write in "int"s (I tested it on
+// the board with consecutive)
+// (see "mailbox_test" in elink/sw0)"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <e-hal.h>
+
+#include "common.h"
+
+uint32_t EXPECTED[NEXPECTED] = {
+	EXPECTED_0,
+	EXPECTED_1,
+	EXPECTED_2,
+	EXPECTED_3,
+	EXPECTED_4,
+	EXPECTED_5,
+	EXPECTED_6,
+	EXPECTED_7,
+};
+
+int main(int argc, char *argv[])
+{
+	uint32_t result[NEXPECTED] = { 0, };
+	unsigned rows, cols, i;
+	e_platform_t platform;
+	e_epiphany_t dev;
+	uint32_t status;
+	const uint32_t one = 1, zero = 0;
+	uint32_t step = 1;
+	bool exit_ok = true;
+	e_mem_t emem;
+
+	// initialize system, read platform params from
+	// default HDF. Then, reset the platform and
+	// get the actual system parameters.
+	e_init(NULL);
+	e_reset_system();
+
+	e_alloc(&emem, DRAM_RESULT_OFFSET, 2*sizeof(result));
+
+	e_get_platform_info(&platform);
+
+	//open the workgroup
+	rows   = platform.rows;
+	cols   = platform.cols;
+	e_open(&dev, 0, 0, rows, cols);
+
+	//load the device program on the board
+	e_load_group("emain.elf", &dev, 0, 0, 1, 1, E_FALSE);
+
+	// Clear DRAM
+	// clear 32-bit write vector (str)
+	e_write(&emem, 0, 0, 0, &result, sizeof(result));
+	// clear 64-bit write test vector (strd)
+	e_write(&emem, 0, 0, sizeof(result), &result, sizeof(result));
+
+
+	// Clear ERAM
+	// clear 32-bit write vector (str)
+	e_write(&dev, 0, 1, ERAM_RESULT_OFFSET, &result, sizeof(result));
+	// clear 64-bit write test vector (strd)
+	e_write(&dev, 0, 1, ERAM_RESULT_OFFSET+sizeof(result), &result, sizeof(result));
+
+
+	// Clear status flag
+	e_write(&dev, 0, 0, STATUS_ADDR, &zero, sizeof(zero));
+
+	e_start(&dev, 0, 0);
+
+	// Wait for test to complete
+	while (true) {
+		usleep(1000000);
+
+		e_read(&dev, 0, 0, STATUS_ADDR, &status, sizeof(status));
+
+		if (status)
+			break;
+	}
+
+	// Check DRAM
+
+	// Check 32-bit results
+	printf("Checking DRAM\n");
+	printf("32-bit STR:\n");
+	e_read(&emem, 0, 0, 0, &result, sizeof(result));
+	for (i = 0; i < NEXPECTED; i++) {
+		if (result[i] != EXPECTED[i]) {
+			exit_ok = false;
+			printf("Fail at %d consecutive writes to same address\n", i + 1);
+		}
+	}
+
+	// Check 64-bit results
+	printf("64-bit STRD:\n");
+	e_read(&emem, 0, 0, sizeof(result), &result, sizeof(result));
+	for (i = 0; i < NEXPECTED; i++) {
+		if (result[i] != EXPECTED[i]) {
+			exit_ok = false;
+			printf("Fail at %d consecutive writes to same address\n", i / 2 + 1);
+		}
+	}
+
+	// Check ERAM
+
+	// Check 32-bit results
+	printf("\nChecking on-chip ERAM\n");
+	printf("32-bit STR:\n");
+	e_read(&dev, 0, 1, ERAM_RESULT_OFFSET, &result, sizeof(result));
+	for (i = 0; i < NEXPECTED; i++) {
+		if (result[i] != EXPECTED[i]) {
+			exit_ok = false;
+			printf("Fail at %d consecutive writes to same address\n", i + 1);
+		}
+
+	}
+
+	// Check 64-bit results
+	printf("64-bit STRD:\n");
+	e_read(&dev, 0, 1, ERAM_RESULT_OFFSET+sizeof(result), &result, sizeof(result));
+	for (i = 0; i < NEXPECTED; i++) {
+		if (result[i] != EXPECTED[i]) {
+			exit_ok = false;
+			printf("Fail at %d consecutive writes to same address\n", i / 2 + 1);
+		}
+	}
+
+	e_close(&dev);
+	e_free(&emem);
+	e_finalize();
+
+	printf(exit_ok ? "\nPASSED\n" : "\nFAILED\n");
+	exit(exit_ok ? EXIT_SUCCESS : EXIT_FAILURE);
+}


### PR DESCRIPTION
Add test for writes to same address. Apparently consecutive 64-bit
writes to the same address can turn into burst writes.

From:
https://github.com/parallella/oh/issues/37

Andreas:

> Remembered that we have a long forgotten mode in the epiphany chip elink
> (not impemented in the fpga elink) that creates bursts when you write
> doubles to the same address. (F**K!)
> So the writes were likely coming in as bursts.
> Looks like the mailbox works fine when you write in "int"s (I tested it on
> the board with consecutive)
> (see "mailbox_test" in elink/sw0)

Signed-off-by: Ola Jeppsson ola@adapteva.com
