### PR TITLE
Fix FIFO async breakage because of undefined CFG_TARGET

### DIFF
--- a/common/hdl/oh_fifo_async.v
+++ b/common/hdl/oh_fifo_async.v
@@ -1,3 +1,8 @@
+// HACK
+`ifndef CFG_TARGET
+`define CFG_TARGET "XILINX"
+`endif
+
 module oh_fifo_async (/*AUTOARG*/
    // Outputs
    dout, full, prog_full, empty, rd_count,


### PR DESCRIPTION
This works but I'm not sure if this is the proper way to fix it. Shouldn't the module that uses oh_fifo_async also make sure that CFG_TARGET is defined?
