### PR TITLE
GPIO: Remove direction cache variable

### DIFF
--- a/src/gpio/driver/gpio-generic.h
+++ b/src/gpio/driver/gpio-generic.h
@@ -5,7 +5,6 @@
 
 struct gpio_generic_dev {
 	volatile struct gpio_registers *regs;
-	uint64_t dircache;
 };
 
 __unused
@@ -16,13 +15,11 @@ static int _gpio_set_direction(struct gpio_generic_dev *dev, unsigned gpio,
 		return -EINVAL;
 
 	if (direction == GPIO_DIR_OUT)
-		dev->dircache |= (1ULL << gpio);
+		dev->regs->dir |= 1ULL << gpio;
 	else if (direction == GPIO_DIR_IN)
-		dev->dircache &= ~(1ULL << gpio);
+		dev->regs->dir &= ~(1ULL << gpio);
 	else
 		return -EINVAL;
-
-	dev->regs->dir = dev->dircache;
 
 	return 0;
 }

--- a/src/gpio/driver/gpio-simple.h
+++ b/src/gpio/driver/gpio-simple.h
@@ -18,7 +18,6 @@ static int gpio_init(gpio_dev_t *dev, void *arg)
 #endif
 
 	dev->regs = (struct gpio_registers *) arg;
-	dev->dircache = 0;
 
 	return 0;
 }


### PR DESCRIPTION
Not needed now that GPIO_DIR is readable.

Signed-off-by: Ola Jeppsson ola@adapteva.com
