### PR TITLE
Vivado doesn't like localparam / clog2 combo

### DIFF
--- a/src/common/hdl/oh_bin2onehot.v
+++ b/src/common/hdl/oh_bin2onehot.v
@@ -11,7 +11,7 @@ module oh_bin2onehot #(parameter DW = 32) // width of data inputs
  output [DW-1:0] out   // one hot output vector
  );
    
-   localparam NB = $clog2(DW);  // encoded bit width
+   parameter NB = $clog2(DW);  // encoded bit width
    
    integer 	  i;      
    reg [DW-1:0] 	  out;  

--- a/src/common/hdl/oh_debouncer.v
+++ b/src/common/hdl/oh_debouncer.v
@@ -18,7 +18,7 @@ module oh_debouncer #( parameter BOUNCE     = 100,    // bounce time (s)
    //################################
    //# wires/regs/ params
    //################################     
-   localparam integer CW  = $clog2(BOUNCE/CLKPERIOD);// counter width needed
+   parameter integer CW  = $clog2(BOUNCE/CLKPERIOD);// counter width needed
      
    //regs
    reg 	  noisy_reg;

--- a/src/common/hdl/oh_memory_dp.v
+++ b/src/common/hdl/oh_memory_dp.v
@@ -8,7 +8,8 @@
 module oh_memory_dp # (parameter DW    = 104,      //memory width
 		       parameter DEPTH = 32,       //memory depth
 		       parameter PROJ  = "",       //project name
-		       parameter MCW   = 8         //repair/config vector width
+		       parameter MCW   = 8,         //repair/config vector width
+		       parameter AW    = $clog2(DEPTH) // address bus width
 		       ) 
    (// Memory interface (dual port)
     input 	    wr_clk, //write clock
@@ -35,7 +36,6 @@ module oh_memory_dp # (parameter DW    = 104,      //memory width
     input [DW-1:0]  bist_din  // data input
     );
    
-   localparam AW      = $clog2(DEPTH);  // address bus width  
 
 `ifdef CFG_ASIC
    //NOT IMPLEMENTED

--- a/src/common/hdl/oh_memory_ram.v
+++ b/src/common/hdl/oh_memory_ram.v
@@ -21,7 +21,7 @@ module oh_memory_ram  # (parameter DW    = 104,  //memory width
     input [DW-1:0]  wr_din // data input
     );
 
-   localparam AW      = $clog2(DEPTH);  // address bus width  
+   parameter AW      = $clog2(DEPTH);  // address bus width  
    
    reg [DW-1:0]        ram    [DEPTH-1:0];  
    reg [DW-1:0]        rd_dout;

--- a/src/common/hdl/oh_memory_sp.v
+++ b/src/common/hdl/oh_memory_sp.v
@@ -33,7 +33,7 @@ module oh_memory_sp  # (parameter DW    = 104,  //memory width
     input [DW-1:0]  bist_din  // data input
     );
 
-   localparam AW      = $clog2(DEPTH);  // address bus width  
+   parameter AW      = $clog2(DEPTH);  // address bus width  
   
 `ifdef CFG_ASIC
 

--- a/src/common/hdl/oh_par2ser.v
+++ b/src/common/hdl/oh_par2ser.v
@@ -24,7 +24,7 @@ module oh_par2ser #(parameter  PW   = 64, // parallel packet width
     );
  
    // parameters  
-   localparam CW   = $clog2(PW/SW);  // serialization factor (for counter)      
+   parameter CW   = $clog2(PW/SW);  // serialization factor (for counter)      
 
    reg [PW-1:0]    shiftreg;
    reg [CW-1:0]    count;

--- a/src/common/hdl/oh_ser2par.v
+++ b/src/common/hdl/oh_ser2par.v
@@ -16,7 +16,7 @@ module oh_ser2par #(parameter PW = 64, // parallel packet width
     input 	    shift      // shift the shifter
     );
  
-   localparam CW   = $clog2(PW/SW);  // serialization factor (for counter)
+   parameter CW   = $clog2(PW/SW);  // serialization factor (for counter)
    
    reg [PW-1:0]    dout;
    reg [CW-1:0]    count;

--- a/src/mio/hdl/mrx_protocol.v
+++ b/src/mio/hdl/mrx_protocol.v
@@ -12,7 +12,7 @@ module mrx_protocol (/*AUTOARG*/
    //parameters
    parameter  PW   = 104;               // packet width (core)
    parameter  NMIO = 8;                 // io packet width
-   localparam CW   = $clog2(2*PW/NMIO); // transfer count width
+   parameter  CW   = $clog2(2*PW/NMIO); // transfer count width
    
    //clock and reset
    input              rx_clk;        // rx clock

--- a/src/mio/hdl/mtx.v
+++ b/src/mio/hdl/mtx.v
@@ -16,7 +16,7 @@ module mtx (/*AUTOARG*/
    parameter NMIO       = 8;                 // IO data width
    parameter FIFO_DEPTH = 32;                // fifo depth  
    parameter TARGET     = "GENERIC";         // GENERIC,XILINX,ALTERA,ASIC
-   localparam CW        = $clog2(2*PW/NMIO); // transfer count width
+   parameter CW         = $clog2(2*PW/NMIO); // transfer count width
 
    //reset, clk, cfg
    input             clk;         // main core clock   

--- a/src/spi/hdl/spi_master_fifo.v
+++ b/src/spi/hdl/spi_master_fifo.v
@@ -14,8 +14,8 @@ module spi_master_fifo (/*AUTOARG*/
    parameter  AW    = 32;            // architecture address width
    parameter  SW    = 8;             // output packet width   
    localparam PW    = 2*AW+40;       // input packet width   
-   localparam FAW   = $clog2(DEPTH); // fifo address width   
-   localparam SRW   = $clog2(PW/SW); // serializer cycle count width
+   parameter  FAW   = $clog2(DEPTH); // fifo address width   
+   parameter  SRW   = $clog2(PW/SW); // serializer cycle count width
    
    //clk,reset, cfg
    input            clk;            // clk


### PR DESCRIPTION
Using parameter instead works.

Signed-off-by: Ola Jeppsson ola@adapteva.com
