### PR TITLE
[RFC] GPIO: Change behavior of IMASK

### DIFF
--- a/src/gpio/hdl/gpio.v
+++ b/src/gpio/hdl/gpio.v
@@ -188,13 +188,13 @@ module gpio #(
        gpio_ilat[N-1:0] <= 'b0;
      else
        gpio_ilat[N-1:0] <= (gpio_ilat[N-1:0] & ~ilat_clr[N-1:0]) |  //old values
-			   (irq_event[N-1:0] & ~gpio_imask[N-1:0]); //new interrupts
+			   irq_event[N-1:0]; //new interrupts
 
    //################################
    //# ONE CYCLE IRQ PULSE
    //################################ 
 
-   assign gpio_irq = |gpio_ilat[N-1:0];
+   assign gpio_irq = |(gpio_ilat[N-1:0] & ~gpio_imask[N-1:0]);
    
    //################################
    //# READBACK


### PR DESCRIPTION
Do not mask ILAT with IMASK. Instead mask gpio_irq with IMASK.

This should work better with edge triggered interrupts where you want to
ack (+mask) the interrupt early in the interrupt handler so that you can
receive one (but only one) consecutive interrupt on the same pin while
still in the interrupt handler.

Not 100% about this but this seems to be the way Linux wants interrupt
controllers to behave.

Signed-off-by: Ola Jeppsson ola@adapteva.com
