### PR TITLE
esaxi: Explicitly reset timeout counter on reset

### DIFF
--- a/axi/hdl/esaxi.v
+++ b/axi/hdl/esaxi.v
@@ -509,7 +509,7 @@ module esaxi (/*autoarg*/
    	   
    //release bus after 64K clock cycles (seems reasonable?)   
    always @ (posedge s_axi_aclk)
-     if(timeout_state[1:0]==`TIMEOUT_IDLE)
+     if (!s_axi_aresetn || timeout_state[1:0]==`TIMEOUT_IDLE)
        timeout_counter[TW-1:0] <= {(TW){1'b1}};   
      else if (timeout_state[1:0]==`TIMEOUT_ARMED)  //decrement while counter > 0
        timeout_counter[TW-1:0] <= timeout_counter[TW-1:0] - 1'b1;


### PR DESCRIPTION
This _might be_ the fix for occasional ghost external fetch abort errors
(once every +50k reset cycle), or at worst be a no-op.

What's strange is that these errors don't seem to be tied to a task
(usually you get PID+task name or a backtrace if it occurs in kernel
code). Almost as if there was no real bus access !?!?.
Could also be caused by some MMU/TLB/... race in the kernel.

Haven't seen this until recently after I rewrote the locking in the
driver vm code (other external fetch errors). It's so simplified now I
don't see how the bug could be in the driver code.

Verified with parallella-linux branch devel-on-4.4

commit adefebad7a8873095636dd75410896e97f7841dc
Author: Ola Jeppsson ola@adapteva.com
Date:   Tue Apr 26 13:46:11 2016 +0200

```
epiphany: Rewrite of vm freeze
```

Signed-off-by: Ola Jeppsson ola@adapteva.com
