### PR TITLE
Gpio fpga project

### DIFF
--- a/src/gpio/fpga/run_params.tcl
+++ b/src/gpio/fpga/run_params.tcl
@@ -16,4 +16,7 @@ set ip_repos [list "."]
 set hdl_files []
 
 #All constraints files
-set constraints_files []
+set constraints_files [list \
+	../../parallella/fpga/parallella_io.xdc \
+	../../parallella/fpga/parallella_7020_io.xdc \
+	]

--- a/src/gpio/fpga/system_bd.tcl
+++ b/src/gpio/fpga/system_bd.tcl
@@ -163,7 +163,8 @@ CONFIG.PCW_EN_CLK3_PORT {1} CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ {100} \
 CONFIG.PCW_FPGA3_PERIPHERAL_FREQMHZ {100} CONFIG.PCW_GPIO_EMIO_GPIO_ENABLE {1} \
 CONFIG.PCW_GPIO_MIO_GPIO_ENABLE {1} CONFIG.PCW_GPIO_MIO_GPIO_IO {MIO} \
 CONFIG.PCW_I2C0_I2C0_IO {EMIO} CONFIG.PCW_I2C0_PERIPHERAL_ENABLE {1} \
-CONFIG.PCW_I2C0_RESET_ENABLE {0} CONFIG.PCW_PRESET_BANK1_VOLTAGE {LVCMOS 1.8V} \
+CONFIG.PCW_I2C0_RESET_ENABLE {0} CONFIG.PCW_IRQ_F2P_INTR {1} \
+CONFIG.PCW_IRQ_F2P_MODE {DIRECT} CONFIG.PCW_PRESET_BANK1_VOLTAGE {LVCMOS 1.8V} \
 CONFIG.PCW_QSPI_GRP_SINGLE_SS_ENABLE {1} CONFIG.PCW_QSPI_PERIPHERAL_ENABLE {1} \
 CONFIG.PCW_SD1_PERIPHERAL_ENABLE {1} CONFIG.PCW_SD1_SD1_IO {MIO 10 .. 15} \
 CONFIG.PCW_SDIO_PERIPHERAL_FREQMHZ {50} CONFIG.PCW_UART1_PERIPHERAL_ENABLE {1} \
@@ -186,17 +187,24 @@ CONFIG.PCW_USE_S_AXI_HP1 {1}  ] $processing_system7_0
   set processing_system7_0_axi_periph [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 processing_system7_0_axi_periph ]
   set_property -dict [ list CONFIG.NUM_MI {1}  ] $processing_system7_0_axi_periph
 
+  # Create instance: sys_concat_intc, and set properties
+  set sys_concat_intc [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 sys_concat_intc ]
+  set_property -dict [ list CONFIG.NUM_PORTS {16}  ] $sys_concat_intc
+
   # Create interface connections
   connect_bd_intf_net -intf_net processing_system7_0_M_AXI_GP1 [get_bd_intf_pins processing_system7_0/M_AXI_GP1] [get_bd_intf_pins processing_system7_0_axi_periph/S00_AXI]
   connect_bd_intf_net -intf_net processing_system7_0_axi_periph_M00_AXI [get_bd_intf_pins parallella_gpio_0/s_axi] [get_bd_intf_pins processing_system7_0_axi_periph/M00_AXI]
 
   # Create port connections
+  connect_bd_net -net parallella_gpio_0_constant_zero [get_bd_pins sys_concat_intc/In0] [get_bd_pins sys_concat_intc/In1] [get_bd_pins sys_concat_intc/In2] [get_bd_pins sys_concat_intc/In3] [get_bd_pins sys_concat_intc/In4] [get_bd_pins sys_concat_intc/In5] [get_bd_pins sys_concat_intc/In6] [get_bd_pins sys_concat_intc/In7] [get_bd_pins sys_concat_intc/In8] [get_bd_pins sys_concat_intc/In9] [get_bd_pins sys_concat_intc/In11] [get_bd_pins sys_concat_intc/In12] [get_bd_pins sys_concat_intc/In13] [get_bd_pins sys_concat_intc/In14] [get_bd_pins sys_concat_intc/In15]
+  connect_bd_net -net parallella_gpio_0_gpio_irq [get_bd_pins parallella_gpio_0/gpio_irq] [get_bd_pins sys_concat_intc/In10]
   connect_bd_net -net parallella_gpio_0_gpio_n [get_bd_ports gpio_n] [get_bd_pins parallella_gpio_0/gpio_n]
   connect_bd_net -net parallella_gpio_0_gpio_p [get_bd_ports gpio_p] [get_bd_pins parallella_gpio_0/gpio_p]
   connect_bd_net -net proc_sys_reset_0_interconnect_aresetn [get_bd_pins proc_sys_reset_0/interconnect_aresetn] [get_bd_pins processing_system7_0_axi_periph/ARESETN]
   connect_bd_net -net proc_sys_reset_0_peripheral_aresetn [get_bd_pins parallella_gpio_0/s_axi_aresetn] [get_bd_pins parallella_gpio_0/sys_nreset] [get_bd_pins proc_sys_reset_0/peripheral_aresetn] [get_bd_pins processing_system7_0_axi_periph/M00_ARESETN] [get_bd_pins processing_system7_0_axi_periph/S00_ARESETN]
   connect_bd_net -net processing_system7_0_FCLK_CLK0 [get_bd_pins parallella_gpio_0/sys_clk] [get_bd_pins proc_sys_reset_0/slowest_sync_clk] [get_bd_pins processing_system7_0/FCLK_CLK0] [get_bd_pins processing_system7_0/M_AXI_GP0_ACLK] [get_bd_pins processing_system7_0/M_AXI_GP1_ACLK] [get_bd_pins processing_system7_0/S_AXI_HP1_ACLK] [get_bd_pins processing_system7_0_axi_periph/ACLK] [get_bd_pins processing_system7_0_axi_periph/M00_ACLK] [get_bd_pins processing_system7_0_axi_periph/S00_ACLK]
   connect_bd_net -net processing_system7_0_FCLK_RESET0_N [get_bd_pins proc_sys_reset_0/ext_reset_in] [get_bd_pins processing_system7_0/FCLK_RESET0_N]
+  connect_bd_net -net sys_concat_intc_dout [get_bd_pins processing_system7_0/IRQ_F2P] [get_bd_pins sys_concat_intc/dout]
 
   # Create address segments
   create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces processing_system7_0/Data] [get_bd_addr_segs parallella_gpio_0/s_axi/axi_lite] SEG_parallella_gpio_0_axi_lite

--- a/src/gpio/fpga/system_bd.tcl
+++ b/src/gpio/fpga/system_bd.tcl
@@ -145,6 +145,8 @@ proc create_root_design { parentCell } {
   # Create interface ports
 
   # Create ports
+  set gpio_n [ create_bd_port -dir IO -from 23 -to 0 gpio_n ]
+  set gpio_p [ create_bd_port -dir IO -from 23 -to 0 gpio_p ]
 
   # Create instance: parallella_gpio_0, and set properties
   set parallella_gpio_0 [ create_bd_cell -type ip -vlnv www.parallella.org:user:parallella_gpio:1.0 parallella_gpio_0 ]
@@ -189,6 +191,8 @@ CONFIG.PCW_USE_S_AXI_HP1 {1}  ] $processing_system7_0
   connect_bd_intf_net -intf_net processing_system7_0_axi_periph_M00_AXI [get_bd_intf_pins parallella_gpio_0/s_axi] [get_bd_intf_pins processing_system7_0_axi_periph/M00_AXI]
 
   # Create port connections
+  connect_bd_net -net parallella_gpio_0_gpio_n [get_bd_ports gpio_n] [get_bd_pins parallella_gpio_0/gpio_n]
+  connect_bd_net -net parallella_gpio_0_gpio_p [get_bd_ports gpio_p] [get_bd_pins parallella_gpio_0/gpio_p]
   connect_bd_net -net proc_sys_reset_0_interconnect_aresetn [get_bd_pins proc_sys_reset_0/interconnect_aresetn] [get_bd_pins processing_system7_0_axi_periph/ARESETN]
   connect_bd_net -net proc_sys_reset_0_peripheral_aresetn [get_bd_pins parallella_gpio_0/s_axi_aresetn] [get_bd_pins parallella_gpio_0/sys_nreset] [get_bd_pins proc_sys_reset_0/peripheral_aresetn] [get_bd_pins processing_system7_0_axi_periph/M00_ARESETN] [get_bd_pins processing_system7_0_axi_periph/S00_ARESETN]
   connect_bd_net -net processing_system7_0_FCLK_CLK0 [get_bd_pins parallella_gpio_0/sys_clk] [get_bd_pins proc_sys_reset_0/slowest_sync_clk] [get_bd_pins processing_system7_0/FCLK_CLK0] [get_bd_pins processing_system7_0/M_AXI_GP0_ACLK] [get_bd_pins processing_system7_0/M_AXI_GP1_ACLK] [get_bd_pins processing_system7_0/S_AXI_HP1_ACLK] [get_bd_pins processing_system7_0_axi_periph/ACLK] [get_bd_pins processing_system7_0_axi_periph/M00_ACLK] [get_bd_pins processing_system7_0_axi_periph/S00_ACLK]

--- a/src/gpio/hdl/parallella_gpio.v
+++ b/src/gpio/hdl/parallella_gpio.v
@@ -44,7 +44,6 @@ module parallella_gpio(/*AUTOARG*/
    wire  [NGPIO-1:0]	gpio_dir;		// oh gpio direction
    wire  [NGPIO-1:0]	pgpio_in;		// parallella gpio in
    wire  [NGPIO-1:0]	pgpio_out;		// parallella gpio out
-   wire  [NGPIO-1:0]	pgpio_tristate; 	// parallella gpio bidirectional
 
    /*AUTOINPUT*/
    // Beginning of automatic inputs (from unused autoinst inputs)
@@ -98,17 +97,11 @@ module parallella_gpio(/*AUTOARG*/
 
    /*AUTOREG*/
 
-   oh_tristate #(.N(NGPIO))
-   tristate (
-	     .oe			(gpio_dir[NGPIO-1:0]),
-	     .in			(gpio_in[NGPIO-1:0]),
-	     .io			(pgpio_tristate[NGPIO-1:0]),
-	     .out			(gpio_out[NGPIO-1:0]));
 
    pgpio #(.NGPIO(NGPIO),.NPS(NGPIO))
-   pgpio (.ps_gpio_i			(pgpio_in[NGPIO-1:0]),
-	  .ps_gpio_o			(pgpio_out[NGPIO-1:0]),
-	  .ps_gpio_t			(pgpio_tristate[NGPIO-1:0]),
+   pgpio (.ps_gpio_i			(gpio_in[NGPIO-1:0]),
+	  .ps_gpio_o			(gpio_out[NGPIO-1:0]),
+	  .ps_gpio_t			(~gpio_dir[NGPIO-1:0]),
 	  /*AUTOINST*/
 	  // Inouts
 	  .gpio_p			(gpio_p[NGPIO-1:0]),

--- a/src/gpio/hdl/parallella_gpio.v
+++ b/src/gpio/hdl/parallella_gpio.v
@@ -19,7 +19,7 @@ module parallella_gpio(/*AUTOARG*/
    s_axi_awcache, s_axi_awburst, s_axi_awaddr, s_axi_arvalid,
    s_axi_arsize, s_axi_arqos, s_axi_arprot, s_axi_arlock, s_axi_arlen,
    s_axi_arid, s_axi_aresetn, s_axi_arcache, s_axi_arburst,
-   s_axi_araddr, sys_nreset, sys_clk
+   s_axi_araddr, constant_zero, constant_one, sys_nreset, sys_clk
    );
 
    //########################################################
@@ -31,6 +31,10 @@ module parallella_gpio(/*AUTOARG*/
    parameter ID		= 12'h820;		// addr[31:20] id
    parameter S_IDW	= 12;			// ID width for S_AXI
    parameter NGPIO	= 24;			// number of gpio pins
+
+   // constants
+   input		constant_zero;		// Always 0
+   input		constant_one;		// Always 1
 
    //clk, reset
    input		sys_nreset;		// active low async reset
@@ -97,6 +101,8 @@ module parallella_gpio(/*AUTOARG*/
 
    /*AUTOREG*/
 
+   assign constant_zero = 1'b0;
+   assign constant_one = 1'b1;
 
    pgpio #(.NGPIO(NGPIO),.NPS(NGPIO))
    pgpio (.ps_gpio_i			(gpio_in[NGPIO-1:0]),


### PR DESCRIPTION
Reading and writing from Porcupine pins now works.

There's something wrong with edge-triggered interrupts (what you can get via sysfs).
Loks like clearing the interrupt (in the interrupt handler) will create a new edge and a new interrupt and ... spam the system with interrupts. Will look into that next.
