### PR TITLE
GPIO: Update Linux driver

### DIFF
--- a/src/gpio/driver/linux/Documentation/devicetree/bindings/gpio/gpio-oh.txt
+++ b/src/gpio/driver/linux/Documentation/devicetree/bindings/gpio/gpio-oh.txt
@@ -18,6 +18,7 @@ Required properties:
       2 = falling edge triggered.
       4 = active high level-sensitive.
       8 = active low level-sensitive.
+- ngpios: number of GPIOs this controller has
 
 Example:
 
@@ -30,4 +31,5 @@ gpio0: gpio0 {
 	#gpio-cells = <2>;
 	interrupt-controller;
 	#interrupt-cells = <2>;
+	ngpios = <24>;
 };


### PR DESCRIPTION
Branch with full history here:
https://github.com/parallella/parallella-linux/tree/oh-gpio

ChangeLog:

commit eb190fa4891cf2c2d33f263d51c566ebb15ac9a1
Author: Ola Jeppsson ola@adapteva.com
Date:   Tue May 3 23:27:52 2016 +0200

gpio: oh: Interrupt detection is disabled for masked interrupts

The OH GPIO controller disables interrupt detection for masked
interrupts so we don't need to provide a irq_enable() to protect from
spurious interrupts.

Nor do we need to mask ILAT against IMASK to get pending interrupts in
the interrupt handler.

commit 366257c1893199d3dba5f3768df8b235d702f56e
Author: Ola Jeppsson ola@adapteva.com
Date:   Tue May 3 23:18:50 2016 +0200

gpio: oh: Fix mix-up of level/edge interrupt types

The OH GPIO documentation incorrectly states that level type interrupts
are the default, when it's the opposite (edge) in RTL code.

commit ecd55cda6ea9967fb98cf89f1f6c622d2ac8d390
Author: Ola Jeppsson ola@adapteva.com
Date:   Tue May 3 19:35:10 2016 +0200

gpio: oh: Remove irq member from struct oh_gpio

We only use the irq number in oh_gpio_probe(), after that it's managed
by devm.

commit 582ab5097fe59b389218deb509619bfc313cab27
Author: Ola Jeppsson ola@adapteva.com
Date:   Fri Apr 29 15:17:49 2016 +0200

gpio: oh: Limit to 32-bit register access if possible

Limit to 32-bit register access when ngpios is less than 32.  Current
oh-gpio HDL code does not support split access to the upper 32-bits of a
register, so right now we're limited to 32 GPIOs on 32-bit
architectures.

commit 5cb10394ba6b524c6acfe82e7481d86473ace453
Author: Ola Jeppsson ola@adapteva.com
Date:   Fri Apr 29 13:45:46 2016 +0200

gpio: oh: Add ngpios property

Signed-off-by: Ola Jeppsson ola@adapteva.com
