### PR TITLE
oh_add: Fix typo in the function description

### DIFF
--- a/src/common/hdl/oh_add.v
+++ b/src/common/hdl/oh_add.v
@@ -1,5 +1,5 @@
 //#############################################################################
-//# Function: Two's compliment adder/subtractor                               #
+//# Function: Two's complement adder/subtractor                               #
 //#############################################################################
 //# Author:   Andreas Olofsson                                                #
 //# License:  MIT (see LICENSE file in OH! repository)                        # 


### PR DESCRIPTION
Fixes a small typo in the description of the adder-subtractor (two's complement representation).
