### PR TITLE
Fixes required for Vivado 2017.4.

### DIFF
--- a/common/hdl/oh_abs.v
+++ b/common/hdl/oh_abs.v
@@ -1,4 +1,8 @@
-module oh_abs (/*AUTOARG*/);
+module oh_abs (/*AUTOARG*/
+   a,
+   out,
+   overflow
+);
 
    //###############################################################
    //# Parameters

--- a/common/hdl/oh_counter.v
+++ b/common/hdl/oh_counter.v
@@ -30,6 +30,7 @@ module oh_counter (/*AUTOARG*/
    //# Interface
    //###############################################################
    reg [DW-1:0]    count;
+   wire [DW-1:0]   count_in;
    
    always @(posedge clk)
      if(load)

--- a/common/hdl/oh_hamming_encoder.v
+++ b/common/hdl/oh_hamming_encoder.v
@@ -5,7 +5,10 @@ module oh_hamming_enc (/*AUTOARG*/
    in, reset
    );
 
- 
+   output out;
+
+   input in;
+   input reset;
 endmodule // oh_hamming_enc
 
 

--- a/common/hdl/oh_mux.v
+++ b/common/hdl/oh_mux.v
@@ -30,7 +30,7 @@ module oh_mux (/*AUTOARG*/
      begin
 	out[DW-1:0] = 'b0;
 	for(i=0;i<N;i=i+1)
-	  out[DW-1:0] |= {(DW){sel[i]}} & in[((i+1)*DW-1)-:DW];
+	  out[DW-1:0] = out[DW-1:0] | {(DW){sel[i]}} & in[((i+1)*DW-1)-:DW];
      end
 
 endmodule // oh_mux


### PR DESCRIPTION
I had to make these changes to parallella_base in order to create a headless_e16_z7020 bitstream using Vivado 2017.4, which would otherwise bail on syntax errors.

> % file ./system.runs/impl_1/system_wrapper.bit
./system.runs/impl_1/system_wrapper.bit: Xilinx BIT data - from > system_wrapper;UserID=0XFFFFFFFF;Version=2017.4 - for 7z020clg400 - built 2018/02/04(18:45:51) - data length 0x3dbafc`

Tested:

> % ./src/parallella-examples/eprime/run.sh 
Core (00,00) Tests: 273733 Primes: 36752 Current: 8759459 SQ: 2959
Core (00,01) Tests: 274105 Primes: 36688 Current: 8771365 SQ: 2961
Core (00,02) Tests: 274103 Primes: 36685 Current: 8771303 SQ: 2961
Core (00,03) Tests: 273819 Primes: 36675 Current: 8762249 SQ: 2960
Core (01,00) Tests: 273996 Primes: 36723 Current: 8767883 SQ: 2961
Core (01,01) Tests: 273687 Primes: 36793 Current: 8757997 SQ: 2959
Core (01,02) Tests: 273907 Primes: 36743 Current: 8765039 SQ: 2960
Core (01,03) Tests: 273742 Primes: 36707 Current: 8759761 SQ: 2959
Core (02,00) Tests: 273897 Primes: 36734 Current: 8764723 SQ: 2960
Core (02,01) Tests: 273628 Primes: 36797 Current: 8756117 SQ: 2959
Core (02,02) Tests: 273625 Primes: 36804 Current: 8756055 SQ: 2959
Core (02,03) Tests: 274008 Primes: 36683 Current: 8768281 SQ: 2961
Core (03,00) Tests: 273767 Primes: 36779 Current: 8760571 SQ: 2959
Core (03,01) Tests: 274000 Primes: 36711 Current: 8768029 SQ: 2961
Core (03,02) Tests: 273684 Primes: 36755 Current: 8757919 SQ: 2959
Core (03,03) Tests: 273979 Primes: 36672 Current: 8767361 SQ: 2960
Total tests: 4381680 Found primes: 587701
Iterations/sec: 405640.0000000`